### PR TITLE
Add support for generic unix socket forwarding

### DIFF
--- a/build/vmconfig/flags.go
+++ b/build/vmconfig/flags.go
@@ -22,3 +22,14 @@ func (f *intListFlag) Set(s string) error {
 	}
 	return nil
 }
+
+type socketListFlag []string
+
+func (f *socketListFlag) String() string {
+	return fmt.Sprint(*f)
+}
+
+func (f *socketListFlag) Set(s string) error {
+	*f = append(*f, strings.Split(s, ",")...)
+	return nil
+}

--- a/build/vmconfig/vm.go
+++ b/build/vmconfig/vm.go
@@ -56,7 +56,8 @@ type VMConfig struct {
 
 	// The code around this was remove so it really doesn't do anything right now.
 	// Keeping for now as fully removing means trashing code that may still be useful.
-	UseVsock bool
+	UseVsock       bool
+	SocketForwards socketListFlag
 }
 
 func (c VMConfig) AsFlags() []string {
@@ -75,6 +76,9 @@ func (c VMConfig) AsFlags() []string {
 	}
 	if len(c.PortForwards) > 0 {
 		flags = append(flags, "--vm-port-forward="+strings.Join(convertPortForwards(c.PortForwards), ","))
+	}
+	if len(c.SocketForwards) > 0 {
+		flags = append(flags, "--vm-socket-forward="+strings.Join(c.SocketForwards, ","))
 	}
 	return flags
 }
@@ -95,6 +99,7 @@ func AddVMFlags(set *flag.FlagSet, cfg *VMConfig) {
 	set.IntVar(&cfg.Gid, "gid", os.Getgid(), "gid to use for the VM")
 	set.BoolVar(&cfg.RequireKVM, "require-kvm", false, "require KVM to be available (will fail if not available)")
 	set.StringVar(&cfg.InitCmd, "init-cmd", "/usr/local/bin/dockerd-init", "command to run in the VM (after pid 1)")
+	set.Var(&cfg.SocketForwards, "vm-socket-forward", "socket forwards to set up from the VM (--vm-socket-foroward=<guest path>)")
 }
 
 var vmxRegexp = regexp.MustCompile(`flags.*:.*(vmx|svm)`)

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -201,7 +201,7 @@ func execVM(ctx context.Context, cfg vmconfig.VMConfig) error {
 	}
 
 	go func() {
-		if err := doSSH(ctx, "/tmp/sockets", sshPort, cfg.Uid, cfg.Gid); err != nil {
+		if err := doSSH(ctx, "/tmp/sockets", sshPort, cfg.Uid, cfg.Gid, cfg.SocketForwards); err != nil {
 			logrus.WithError(err).Error("ssh failed")
 			cancel()
 		}

--- a/cmd/entrypoint/ssh.go
+++ b/cmd/entrypoint/ssh.go
@@ -39,11 +39,11 @@ func generateKeys() ([]byte, []byte, error) {
 	return pub, pem, nil
 }
 
-func doSSH(ctx context.Context, sockDir string, port string, uid, gid int) error {
+func doSSH(ctx context.Context, sockDir string, port string, uid, gid int, forwards []string) error {
 	logrus.Debug("Preparing SSH")
 	fifoPath := filepath.Join(sockDir, "authorized_keys")
 
-	if err := os.MkdirAll(sockDir, 0700); err != nil {
+	if err := mkdirAs(sockDir, 0700, uid, gid); err != nil {
 		return fmt.Errorf("error creating socket directory: %w", err)
 	}
 
@@ -111,8 +111,6 @@ func doSSH(ctx context.Context, sockDir string, port string, uid, gid int) error
 		return fmt.Errorf("error adding private key to ssh-agent: %s: %w", out, err)
 	}
 
-	sock := filepath.Join(sockDir, "docker.sock")
-	unix.Unlink(sock)
 	logrus.Debug(string(out))
 
 	sockKV, _, found := strings.Cut(string(out), ";")
@@ -120,35 +118,124 @@ func doSSH(ctx context.Context, sockDir string, port string, uid, gid int) error
 		return fmt.Errorf("error parsing ssh-agent output: %s", out)
 	}
 
-	for i := 0; ; i++ {
-		cmd = exec.Command(
-			"/usr/bin/ssh",
-			"-f",
-			"-nNT",
-			"-o", "BatchMode=yes",
-			"-o", "StrictHostKeyChecking=no",
-			"-o", "ExitOnForwardFailure=yes",
-			"-L", sock+":/run/docker.sock",
-			"127.0.0.1", "-p", port,
-		)
-		cmd.Env = append(cmd.Env, sockKV)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			if strings.Contains(string(out), "Connection refused") || strings.Contains(string(out), "Connection reset by peer") {
-				if i == 100 {
-					logrus.WithError(err).Warn(string(out))
-					i = 0
-				}
-				time.Sleep(100 * time.Millisecond)
-				continue
-			}
-			return fmt.Errorf("error setting up ssh tunnel: %w: %s", err, string(out))
-		}
-		break
-	}
+	for _, f := range forwards {
 
-	if err := os.Chown(sock, uid, gid); err != nil {
-		return fmt.Errorf("error setting ownership on proxied docker socket: %w", err)
+		go func(f string) {
+			err := func() error {
+				local := filepath.Join(sockDir, "s", f)
+				if err := mkdirAs(filepath.Dir(local), 0750, uid, gid); err != nil {
+					return fmt.Errorf("error creating socket directory: %w", err)
+				}
+
+				for i := 0; ; i++ {
+					cmd = exec.Command(
+						"/usr/bin/ssh",
+						"-f",
+						"-nNT",
+						"-o", "BatchMode=yes",
+						"-o", "StrictHostKeyChecking=no",
+						"-o", "ExitOnForwardFailure=yes",
+						"-L", local+":"+f,
+						"127.0.0.1", "-p", port,
+					)
+					cmd.Env = append(cmd.Env, sockKV)
+
+					if out, err := cmd.CombinedOutput(); err != nil {
+						if strings.Contains(string(out), "Connection refused") || strings.Contains(string(out), "Connection reset by peer") {
+							if i == 100 {
+								logrus.WithError(err).Warn(string(out))
+								i = 0
+							}
+							time.Sleep(100 * time.Millisecond)
+							continue
+						}
+						return fmt.Errorf("error starting ssh tunnel: %w: %s", err, out)
+					}
+					break
+				}
+				if err := os.Chown(local, uid, gid); err != nil {
+					return fmt.Errorf("error chowning socket: %w", err)
+				}
+				return nil
+			}()
+			if err != nil {
+				logrus.WithError(err).Error("error setting up ssh tunnel")
+			}
+		}(f)
 	}
 
 	return nil
+}
+
+// mkdirAs is a modified version of https://github.com/moby/moby/blob/9ff00e35f8833f9876e8919977be56a9aa956937/pkg/idtools/idtools_unix.go#L25
+// Mostly it just uses uid/gids instead of an "Identity" struct and it always does MkdirAll and chowns all the directories.
+func mkdirAs(path string, mode os.FileMode, uid, gid int) error {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	stat, err := os.Stat(path)
+	if err == nil {
+		if !stat.IsDir() {
+			return &os.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
+		}
+
+		// short-circuit -- we were called with an existing directory and chown was requested
+		return setPermissions(path, mode, uid, gid, stat)
+	}
+
+	// make an array containing the original path asked for, plus (for mkAll == true)
+	// all path components leading up to the complete path that don't exist before we MkdirAll
+	// so that we can chown all of them properly at the end.  If chownExisting is false, we won't
+	// chown the full directory path if it exists
+	var paths []string
+	if os.IsNotExist(err) {
+		paths = []string{path}
+	}
+
+	// walk back to "/" looking for directories which do not exist
+	// and add them to the paths array for chown after creation
+	dirPath := path
+	for {
+		dirPath = filepath.Dir(dirPath)
+		if dirPath == "/" {
+			break
+		}
+		if _, err = os.Stat(dirPath); err != nil && os.IsNotExist(err) {
+			paths = append(paths, dirPath)
+		}
+	}
+	if err = os.MkdirAll(path, mode); err != nil {
+		return err
+	}
+
+	// even if it existed, we will chown the requested path + any subpaths that
+	// didn't exist when we called MkdirAll
+	for _, pathComponent := range paths {
+		if err = setPermissions(pathComponent, mode, uid, gid, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setPermissions(p string, mode os.FileMode, uid, gid int, stat os.FileInfo) error {
+	if stat == nil {
+		var err error
+		stat, err = os.Stat(p)
+		if err != nil {
+			return err
+		}
+	}
+	if stat.Mode().Perm() != mode.Perm() {
+		if err := os.Chmod(p, mode.Perm()); err != nil {
+			return err
+		}
+	}
+	ssi := stat.Sys().(*syscall.Stat_t)
+	if ssi.Uid == uint32(uid) && ssi.Gid == uint32(gid) {
+		return nil
+	}
+	return os.Chown(p, uid, gid)
 }

--- a/main.go
+++ b/main.go
@@ -62,6 +62,10 @@ func do(ctx context.Context) error {
 
 	flag.Parse()
 
+	if len(cfg.VM.SocketForwards) == 0 {
+		cfg.VM.SocketForwards.Set("/run/docker.sock")
+	}
+
 	if cfg.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
@@ -105,6 +109,10 @@ func do(ctx context.Context) error {
 
 		if err := set.Parse(args); err != nil {
 			return err
+		}
+
+		if len(cfg.VM.SocketForwards) == 0 {
+			cfg.VM.SocketForwards.Set("/run/docker.sock")
 		}
 
 		if cfg.Debug {


### PR DESCRIPTION
When no sockets are being forwarded, and it is using the main cmd at the root of the repo, `/run/docker.sock` is added implicitly.

All sockets are forwarded at the state dir + `/s/<guest path>`